### PR TITLE
Fix a translation error, transactions should be translated to `交易`

### DIFF
--- a/values-zh-rCN/strings.xml
+++ b/values-zh-rCN/strings.xml
@@ -25,7 +25,7 @@
 
     <!-- Tabs -->
     <string name="viewpager_carddetail">卡片详细信息</string>
-    <string name="viewpager_transactions">翻译</string>
+    <string name="viewpager_transactions">交易</string>
     <string name="viewpager_log">日志</string>
 
     <!-- Card Detail -->


### PR DESCRIPTION
Fix a translation error, transactions should be translated to `交易`

`翻译` -> `交易`